### PR TITLE
Fix license references from MIT to GPL-3.0 in website

### DIFF
--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -318,7 +318,7 @@ import Layout from '../layouts/Layout.astro';
 						</svg>
 					</div>
 					<h3 class="text-lg font-semibold text-gray-900 mb-2">Open Source</h3>
-					<p class="text-gray-600">MIT licensed, community-driven development</p>
+					<p class="text-gray-600">GPL-3.0 licensed, community-driven development</p>
 				</div>
 				<div class="text-center p-6">
 					<div class="w-16 h-16 bg-indigo-500 rounded-lg flex items-center justify-center mx-auto mb-4">
@@ -417,7 +417,7 @@ import Layout from '../layouts/Layout.astro';
 				</div>
 			</div>
 			<div class="border-t border-gray-800 mt-8 pt-8 text-center text-gray-400">
-				<p>&copy; 2024 Pixlie. Open source under MIT License.</p>
+				<p>&copy; 2024 Pixlie. Open source under GPL-3.0 License.</p>
 			</div>
 		</div>
 	</footer>


### PR DESCRIPTION
- Update "Open Source" section in index.astro to show GPL-3.0 license
- Update footer copyright notice from MIT to GPL-3.0 license
- Ensure all website license references match actual project license
- Verify website builds successfully after changes

Fixes #62 - Updates website license references for legal consistency

🤖 Generated with [Claude Code](https://claude.ai/code)