### PR TITLE
feat: Complete CLI to TUI-first architecture refactor

### DIFF
--- a/test-workspace-local/.pixlie-workspace.toml
+++ b/test-workspace-local/.pixlie-workspace.toml
@@ -1,0 +1,2 @@
+[metadata]
+name = "local-test"


### PR DESCRIPTION
## Summary
- Refactor CLI from argument-heavy interface to clean TUI-first design
- Remove non-essential CLI arguments (--database, --objective, --model, --max-iterations, --create-config, --show-config, --json-logs, --log-level)
- Keep only --help, --version, and optional workspace path argument
- Add automatic workspace detection in current directory
- Update application to launch TUI interface directly
- Simplify Args struct to minimal interface focused on TUI launch

## Changes
- **main.rs**: Complete refactor of CLI argument handling and startup logic
- **Args struct**: Simplified from 9 arguments to 1 optional workspace path
- **Application flow**: Now launches TUI directly instead of CLI mode
- **Workspace detection**: Auto-detects workspace in current directory tree
- **Configuration**: Loads basic config without CLI overrides

## Testing
- [x] Application builds successfully
- [x] `./pixlie --help` shows clean TUI-first interface
- [x] `./pixlie` launches with workspace auto-detection
- [x] `./pixlie /path/to/workspace` loads specified workspace
- [x] All non-essential CLI arguments removed

## Addresses
Closes #90

🤖 Generated with [Claude Code](https://claude.ai/code)